### PR TITLE
onUnmounted hook destroy fix

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -191,7 +191,7 @@ export default defineComponent({
     expose?.({ jsonEditor })
 
     onUnmounted(() => {
-      jsonEditor.value.destroy()
+      jsonEditor.value?.destroy()
     })
 
     onMounted(() => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The component was crashing when the history pop event happens programmaticaly. The component is using optional chaining for updates but it seems destroy method on the unMounted was forgotten.

### Additional context

```
[Vue warn]: Error in destroyed hook: "TypeError: Cannot read properties of undefined (reading 'destroy')"
```
