### PR TITLE
chore(demo): fix an error in Vue 2.6 demo—Property or method "value" is not defined on the instance but referenced during render

### DIFF
--- a/demo/vue2.6/index.vue
+++ b/demo/vue2.6/index.vue
@@ -12,7 +12,7 @@ export default {
       version: Vue.version,
       data: {
         value: {
-        // bigint: 124124124124124124124n,
+          // bigint: 124124124124124124124n,
           boolean: true,
           string: 'Hello World',
           number: 123.456,
@@ -33,6 +33,11 @@ export default {
   mounted() {
     console.log('expand: ', this.$refs.jsonEditorVueRef.jsonEditor.expand)
   },
+  methods: {
+    onInput(data) {
+      console.log('onInput: ', data)
+    }
+  },
 }
 </script>
 
@@ -49,7 +54,7 @@ export default {
       <button @click="data.value.number = Math.random()">
         改变属性
       </button>
-      <button @click="value = undefined">
+      <button @click="data.value = undefined">
         清空
       </button>
       <button @click="mode = mode === 'text' ? 'tree' : 'text'">
@@ -63,17 +68,18 @@ export default {
     <br>
     <JsonEditorVue
       ref="jsonEditorVueRef"
-      v-model="value"
+      v-model="data.value"
       :mode.sync="mode"
       :readOnly="readOnly"
+      @input="onInput"
     />
 
     <br>
     <p>Mode</p>
     {{ mode }}
     <p>Value</p>
-    {{ value }}
+    {{ data.value }}
     <p>Type</p>
-    {{ typeof value }}
+    {{ typeof data.value }}
   </div>
 </template>

--- a/demo/vue2.6/index.vue
+++ b/demo/vue2.6/index.vue
@@ -33,11 +33,6 @@ export default {
   mounted() {
     console.log('expand: ', this.$refs.jsonEditorVueRef.jsonEditor.expand)
   },
-  methods: {
-    onInput(data) {
-      console.log('onInput: ', data)
-    }
-  },
 }
 </script>
 
@@ -71,7 +66,6 @@ export default {
       v-model="data.value"
       :mode.sync="mode"
       :readOnly="readOnly"
-      @input="onInput"
     />
 
     <br>

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -133,6 +133,7 @@ export default defineComponent({
         () => props[modelValueProp],
         (newModelValue: any) => {
           if (preventUpdatingContent.value) {
+            preventUpdatingContent.value = false
             return
           }
           if (jsonEditor.value) {
@@ -144,9 +145,7 @@ export default defineComponent({
                 // Only default value can clear the editor
                 ? { text: '' }
                 : { json: newModelValue },
-            ).then(() => {
-              preventUpdatingModelValue.value = false
-            })
+            )
           }
         },
         {

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -133,7 +133,6 @@ export default defineComponent({
         () => props[modelValueProp],
         (newModelValue: any) => {
           if (preventUpdatingContent.value) {
-            preventUpdatingContent.value = false
             return
           }
           if (jsonEditor.value) {
@@ -145,7 +144,9 @@ export default defineComponent({
                 // Only default value can clear the editor
                 ? { text: '' }
                 : { json: newModelValue },
-            )
+            ).then(() => {
+              preventUpdatingModelValue.value = false
+            })
           }
         },
         {


### PR DESCRIPTION
### Description

1. Fix errors in Vue2.6 demo
2. Fix the issue of not being able to obtain the latest value of a component when modifying its value for the first time after initializing the assignment and then assigning it to the component again (for example, API returns data and assigns it to the component)

---

1. 修复vue2.6 demo的错误
2. 修复在初始化赋值后，再次赋值给组件后（例如：API返回数据后赋值给组件），第一次修改组件的值时，不能获得组件的最新值的问题

### Additional context

例如：

```vue
<template>
    <JsonEditorVue  v-model="value" mode="text" @input="onInput" />
</template>
<script>
import JsonEditorVue  ......
export default {
  components: { JsonEditorVue },
  data() { return { data: { value: {}, }, } },
  mounted() {
    this.value = [
      {
        a: 'b',
        c: 'd',
      }
    ]
  },
  methods: {
    onInput(data) {
      // 由于在 mounted() 中对 value 再次修改，
      // 所以会导致 `src > Component.ts > onChange` 中的 `preventUpdatingModelValue.value` 为 true，
      // 导致 `onInput` 获取不到第一次修改的值
      console.log('onInput: ', data)
    }
  }
}
</script>
```
